### PR TITLE
fix: ensure schema exists before migrate and cleanAndMigrate

### DIFF
--- a/core/src/main/scala/nomad/Migrator.scala
+++ b/core/src/main/scala/nomad/Migrator.scala
@@ -20,9 +20,14 @@ import scala.util.Using
   * @param historyTable the name of the table used to track applied migrations
   * @param schema the database schema to use for migrations and history tracking
   * @param autoCreateSchema if true (default), the configured schema is created
-  *                         via `CREATE SCHEMA IF NOT EXISTS` at the start of
-  *                         `migrate()` and `cleanAndMigrate()`. Set to false when
-  *                         running under a role that lacks `CREATE` privileges.
+  *                         at the start of `migrate()` and `cleanAndMigrate()`
+  *                         when it does not already exist. Existence is probed
+  *                         via `information_schema.schemata` (readable by
+  *                         `PUBLIC`) and `CREATE SCHEMA` runs only on the
+  *                         missing-schema path, so least-privilege roles with
+  *                         `USAGE` on a pre-existing schema are unaffected.
+  *                         Set to false when running under a role that must
+  *                         never attempt schema creation under any condition.
   */
 class Migrator(
   datasource: DataSource,
@@ -543,13 +548,28 @@ class Migrator(
   }
 
   private def ensureSchemaExists(conn: Connection): Unit = {
+    // Probe via information_schema.schemata (readable by PUBLIC, no privilege
+    // required) and only issue CREATE SCHEMA when absent. Postgres checks
+    // ACL_CREATE on the database before IF NOT EXISTS short-circuits, so a
+    // bare CREATE SCHEMA IF NOT EXISTS would regress least-privilege roles
+    // that hold USAGE on a pre-existing schema but lack CREATE on the database.
+    if (schemaExists(conn)) return
     Using.resource(conn.createStatement()) { stmt =>
       db match {
         case SupportedDatabase.Postgres =>
-          stmt.execute(s"""CREATE SCHEMA IF NOT EXISTS "$schema"""")
+          stmt.execute(s"""CREATE SCHEMA "$schema"""")
         case SupportedDatabase.H2 =>
-          stmt.execute(s"""CREATE SCHEMA IF NOT EXISTS "$schema"""")
+          stmt.execute(s"""CREATE SCHEMA "$schema"""")
       }
+    }
+  }
+
+  private def schemaExists(conn: Connection): Boolean = {
+    Using.resource(
+      conn.prepareStatement("SELECT 1 FROM information_schema.schemata WHERE schema_name = ?")
+    ) { ps =>
+      ps.setString(1, schema)
+      Using.resource(ps.executeQuery())(_.next())
     }
   }
 

--- a/core/src/main/scala/nomad/Migrator.scala
+++ b/core/src/main/scala/nomad/Migrator.scala
@@ -553,13 +553,22 @@ class Migrator(
     // ACL_CREATE on the database before IF NOT EXISTS short-circuits, so a
     // bare CREATE SCHEMA IF NOT EXISTS would regress least-privilege roles
     // that hold USAGE on a pre-existing schema but lack CREATE on the database.
+    //
+    // The probe-then-create sequence is TOCTOU-racy on concurrent cold start:
+    // two horizontally scaled processes can both observe the schema as missing
+    // and then race the CREATE. Keep IF NOT EXISTS on the create path so the
+    // loser's statement is a no-op instead of a 'schema already exists' error.
+    // The ACL_CREATE check IF NOT EXISTS still triggers is acceptable here
+    // because we only reach this branch when the schema was actually missing
+    // at probe time — i.e., forward progress already requires CREATE on the
+    // database, so failing without it is the correct outcome.
     if (schemaExists(conn)) return
     Using.resource(conn.createStatement()) { stmt =>
       db match {
         case SupportedDatabase.Postgres =>
-          stmt.execute(s"""CREATE SCHEMA "$schema"""")
+          stmt.execute(s"""CREATE SCHEMA IF NOT EXISTS "$schema"""")
         case SupportedDatabase.H2 =>
-          stmt.execute(s"""CREATE SCHEMA "$schema"""")
+          stmt.execute(s"""CREATE SCHEMA IF NOT EXISTS "$schema"""")
       }
     }
   }

--- a/core/src/main/scala/nomad/Migrator.scala
+++ b/core/src/main/scala/nomad/Migrator.scala
@@ -19,14 +19,30 @@ import scala.util.Using
   * @param migrations the ordered list of migrations to apply
   * @param historyTable the name of the table used to track applied migrations
   * @param schema the database schema to use for migrations and history tracking
+  * @param autoCreateSchema if true (default), the configured schema is created
+  *                         via `CREATE SCHEMA IF NOT EXISTS` at the start of
+  *                         `migrate()` and `cleanAndMigrate()`. Set to false when
+  *                         running under a role that lacks `CREATE` privileges.
   */
 class Migrator(
   datasource: DataSource,
   db: SupportedDatabase,
   migrations: Vector[Migration],
   historyTable: String = "nomad_migrations",
-  schema: String = "public"
+  schema: String = "public",
+  autoCreateSchema: Boolean = true
 ) {
+
+  // Preserves the 5-arg constructor signature shipped in 0.1.0 so that
+  // Java callers, pre-compiled binaries, and reflective callers using
+  // the old arity keep working after the 0.1.1 bump.
+  def this(
+    datasource: DataSource,
+    db: SupportedDatabase,
+    migrations: Vector[Migration],
+    historyTable: String,
+    schema: String
+  ) = this(datasource, db, migrations, historyTable, schema, autoCreateSchema = true)
 
   final case class FlywayImportAnalysis(
     exactMatchCount: Int,
@@ -68,6 +84,7 @@ class Migrator(
   def migrate(): Unit = {
     val conn = datasource.getConnection
     try {
+      if (autoCreateSchema) ensureSchemaExists(conn)
       setSchemaIfNeeded(conn)
       ensureHistoryTable(conn)
       val applied = loadApplied(conn)
@@ -187,6 +204,7 @@ class Migrator(
   def cleanAndMigrate(): Unit = {
     val conn = datasource.getConnection
     try {
+      if (autoCreateSchema) ensureSchemaExists(conn)
       setSchemaIfNeeded(conn)
       if (isSchemaEmpty(conn)) {
         logger.info("Instructed to clean schema, but schema is empty, nothing to clean.")
@@ -521,6 +539,17 @@ class Migrator(
     val current = conn.getSchema
     if (current == null || !current.equalsIgnoreCase(schema)) {
       conn.setSchema(schema)
+    }
+  }
+
+  private def ensureSchemaExists(conn: Connection): Unit = {
+    Using.resource(conn.createStatement()) { stmt =>
+      db match {
+        case SupportedDatabase.Postgres =>
+          stmt.execute(s"""CREATE SCHEMA IF NOT EXISTS "$schema"""")
+        case SupportedDatabase.H2 =>
+          stmt.execute(s"""CREATE SCHEMA IF NOT EXISTS "$schema"""")
+      }
     }
   }
 

--- a/sbt-plugin/src/main/scala/nomad/sbt/NomadPlugin.scala
+++ b/sbt-plugin/src/main/scala/nomad/sbt/NomadPlugin.scala
@@ -293,6 +293,8 @@ object NomadPlugin extends AutoPlugin {
     val nomadManifestFile = settingKey[File]("Path to the Scala manifest file defining migration order")
     val nomadManifestClass = settingKey[String]("Fully qualified class name of the NomadMigrations implementation")
     val nomadHistoryTable = settingKey[String]("Name of the database table used to track applied migrations")
+    val nomadSchema = settingKey[String]("Database schema used for migrations and history tracking")
+    val nomadAutoCreateSchema = settingKey[Boolean]("Create the configured schema via CREATE SCHEMA IF NOT EXISTS before migrate / cleanAndMigrate. Set to false for least-privilege roles.")
     val nomadGraalSync = settingKey[Boolean]("Automatically sync migration resources to GraalVM native-image resource-config.json")
     val nomadGraalResourceConfigFile = settingKey[File]("Path to the GraalVM resource-config.json file")
     val nomadImportFlyway = taskKey[Unit]("Import Flyway versioned migrations into the Nomad manifest")
@@ -306,6 +308,8 @@ object NomadPlugin extends AutoPlugin {
     nomadManifestFile := (Compile / scalaSource).value / "Nomad.scala",
     nomadManifestClass := ManifestNaming.classNameFromFile(nomadManifestFile.value, (Compile / scalaSource).value),
     nomadHistoryTable := "nomad_migrations",
+    nomadSchema := "public",
+    nomadAutoCreateSchema := true,
     nomadGraalSync := false,
     nomadGraalResourceConfigFile := (Compile / resourceDirectory).value / "META-INF" / "native-image" / "resource-config.json",
     nomadInit / aggregate := false,
@@ -330,6 +334,8 @@ object NomadPlugin extends AutoPlugin {
       val cp = (Compile / fullClasspath).value.files
       val className = nomadManifestClass.value
       val table = nomadHistoryTable.value
+      val schema = nomadSchema.value
+      val autoCreateSchema = nomadAutoCreateSchema.value
 
       val loader = new ChildFirstClassLoader(
         cp.map(_.toURI.toURL).toArray,
@@ -348,8 +354,8 @@ object NomadPlugin extends AutoPlugin {
         val database = databaseMethod.invoke(instance)
 
         val migratorClass = loader.loadClass("nomad.Migrator")
-        val constructor = migratorClass.getConstructors.head
-        val migrator = constructor.newInstance(datasource, database, migrations, table, "public")
+        val constructor = migratorClass.getConstructors.maxBy(_.getParameterCount)
+        val migrator = constructor.newInstance(datasource, database, migrations, table, schema, java.lang.Boolean.valueOf(autoCreateSchema))
         val migrateMethod = migratorClass.getMethod("migrate")
         migrateMethod.invoke(migrator)
       } finally {
@@ -370,6 +376,8 @@ object NomadPlugin extends AutoPlugin {
       val cp = (Compile / fullClasspath).value.files
       val className = nomadManifestClass.value
       val table = nomadHistoryTable.value
+      val schema = nomadSchema.value
+      val autoCreateSchema = nomadAutoCreateSchema.value
 
       val loader = new ChildFirstClassLoader(
         cp.map(_.toURI.toURL).toArray,
@@ -388,8 +396,8 @@ object NomadPlugin extends AutoPlugin {
         val database = databaseMethod.invoke(instance)
 
         val migratorClass = loader.loadClass("nomad.Migrator")
-        val constructor = migratorClass.getConstructors.head
-        val migrator = constructor.newInstance(datasource, database, migrations, table, "public")
+        val constructor = migratorClass.getConstructors.maxBy(_.getParameterCount)
+        val migrator = constructor.newInstance(datasource, database, migrations, table, schema, java.lang.Boolean.valueOf(autoCreateSchema))
         val printStatusMethod = migratorClass.getMethod("printStatus")
         val hasProblems = printStatusMethod.invoke(migrator).asInstanceOf[Boolean]
 
@@ -450,6 +458,8 @@ object NomadPlugin extends AutoPlugin {
       val cp = (Compile / fullClasspath).value.files
       val className = nomadManifestClass.value
       val table = nomadHistoryTable.value
+      val schema = nomadSchema.value
+      val autoCreateSchema = nomadAutoCreateSchema.value
       val base = baseDirectory.value
 
       if (!manifest.exists()) {
@@ -539,8 +549,8 @@ object NomadPlugin extends AutoPlugin {
             val migrations = migrationsMethod.invoke(instance)
 
             val migratorClass = loader.loadClass("nomad.Migrator")
-            val constructor = migratorClass.getConstructors.head
-            val migrator = constructor.newInstance(datasource, database, migrations, table, "public")
+            val constructor = migratorClass.getConstructors.maxBy(_.getParameterCount)
+            val migrator = constructor.newInstance(datasource, database, migrations, table, schema, java.lang.Boolean.valueOf(autoCreateSchema))
             val analyzeMethod = migratorClass.getMethod("analyzeFlywayHistoryImport", classOf[String], classOf[Array[String]])
             val analysis = analyzeMethod.invoke(migrator, flywayTable, allPaths.toArray)
 

--- a/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
@@ -138,6 +138,105 @@ object Main {
       conn6.close()
 
       println("Test 5 passed: cleanAndMigrate on empty schema skips clean and migrates")
+
+      // --- Test 6: cleanAndMigrate self-heals when schema does not exist (autoCreateSchema=true) ---
+      val setup5 = ds.getConnection
+      setup5.createStatement().execute("CREATE SCHEMA IF NOT EXISTS will_be_dropped")
+      setup5.close()
+      // Drop it to simulate the bug scenario
+      val drop = ds.getConnection
+      drop.createStatement().execute("DROP SCHEMA will_be_dropped CASCADE")
+      drop.close()
+
+      val missingSchemaMigrator = new Migrator(
+        ds, SupportedDatabase.Postgres, migrations, schema = "will_be_dropped"
+      )
+      missingSchemaMigrator.cleanAndMigrate()
+
+      val conn7 = ds.getConnection
+      conn7.setSchema("will_be_dropped")
+      val rs7 = conn7.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+      rs7.next()
+      assert(rs7.getLong(1) == 1, "Expected 1 migration recorded after self-heal on missing schema")
+      rs7.close()
+      conn7.close()
+
+      println("Test 6 passed: cleanAndMigrate self-heals when schema is missing")
+
+      // --- Test 7: autoCreateSchema=false reproduces the original bug (no silent creation) ---
+      // The exact symptom from the bug report: PG rejects CREATE TYPE because the missing
+      // schema left search_path pointing at a non-existent namespace.
+      val strictMigrator = new Migrator(
+        ds, SupportedDatabase.Postgres, migrations,
+        schema = "never_created", autoCreateSchema = false
+      )
+      try {
+        strictMigrator.cleanAndMigrate()
+        throw new AssertionError("Expected failure when autoCreateSchema=false and schema is missing")
+      } catch {
+        case e: RuntimeException if e.getCause != null
+            && e.getCause.getMessage != null
+            && e.getCause.getMessage.contains("no schema has been selected") =>
+          // expected — this is exactly the original bug symptom surfacing when opt-out is chosen
+        case e: org.postgresql.util.PSQLException if e.getMessage.contains("no schema has been selected") =>
+          // expected — same symptom surfaced directly
+      }
+
+      println("Test 7 passed: autoCreateSchema=false reproduces original bug symptom")
+
+      // --- Test 8: migrate() (without clean) self-heals when schema is missing ---
+      val migrateSelfHeal = new Migrator(
+        ds, SupportedDatabase.Postgres, migrations, schema = "migrate_self_heal"
+      )
+      migrateSelfHeal.migrate()
+
+      val conn8 = ds.getConnection
+      conn8.setSchema("migrate_self_heal")
+      val rs8 = conn8.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+      rs8.next()
+      assert(rs8.getLong(1) == 1, "Expected 1 migration recorded after migrate self-heal on missing schema")
+      rs8.close()
+      conn8.close()
+
+      println("Test 8 passed: migrate self-heals when schema is missing")
+
+      // --- Test 9: canonical bug repro — DROP SCHEMA public CASCADE then cleanAndMigrate ---
+      // This mirrors verbatim the "Steps to reproduce" section of the bug report, and
+      // additionally verifies that the fix is idempotent: a second cleanAndMigrate() call
+      // after self-heal must also converge (the bug was described as self-perpetuating).
+      // Use a fresh embedded PG so earlier tests do not interfere with the public schema.
+      val pg2 = EmbeddedPostgres.start()
+      try {
+        val ds2 = pg2.getPostgresDatabase()
+
+        val dropPublic = ds2.getConnection
+        dropPublic.createStatement().execute("DROP SCHEMA public CASCADE")
+        dropPublic.close()
+
+        val canonicalMigrator = new Migrator(ds2, SupportedDatabase.Postgres, migrations)
+        canonicalMigrator.cleanAndMigrate() // must self-heal (default schema = "public")
+
+        val verify1 = ds2.getConnection
+        val rs9a = verify1.createStatement().executeQuery("SELECT COUNT(*) FROM public.nomad_migrations")
+        rs9a.next()
+        assert(rs9a.getLong(1) == 1, "Canonical repro: expected 1 migration after first cleanAndMigrate")
+        rs9a.close()
+        verify1.close()
+
+        // Second invocation — must not re-perpetuate the bug and must remain at 1 migration
+        canonicalMigrator.cleanAndMigrate()
+
+        val verify2 = ds2.getConnection
+        val rs9b = verify2.createStatement().executeQuery("SELECT COUNT(*) FROM public.nomad_migrations")
+        rs9b.next()
+        assert(rs9b.getLong(1) == 1, "Canonical repro: second cleanAndMigrate must be idempotent")
+        rs9b.close()
+        verify2.close()
+      } finally {
+        pg2.close()
+      }
+
+      println("Test 9 passed: canonical public-schema repro self-heals and is idempotent")
       println("All Postgres cleanAndMigrate tests passed!")
     } finally {
       pg.close()

--- a/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
@@ -253,6 +253,51 @@ object Main {
       }
 
       println("Test 9 passed: canonical public-schema repro self-heals and is idempotent")
+
+      // --- Test 10: autoCreateSchema=true on a pre-existing schema must not require CREATE on the database ---
+      // Regression: Postgres checks ACL_CREATE on the database before IF NOT EXISTS
+      // short-circuits, so a naive CREATE SCHEMA IF NOT EXISTS would fail for a
+      // least-privilege role even when the target schema already exists. The probe-
+      // then-create implementation must take the no-op path for this role.
+      val pg3 = startEmbeddedPostgres()
+      try {
+        val dsAdmin = pg3.getPostgresDatabase()
+        val admin = dsAdmin.getConnection
+        try {
+          admin.createStatement().execute("CREATE ROLE limited_user LOGIN")
+          admin.createStatement().execute("CREATE SCHEMA limited_pre_existing")
+          admin.createStatement().execute(
+            "GRANT USAGE, CREATE ON SCHEMA limited_pre_existing TO limited_user"
+          )
+          // Defense-in-depth: revoke any default CREATE-on-database grant. PG 15+
+          // already revokes CREATE on database from PUBLIC by default; older PGs do not.
+          admin.createStatement().execute("REVOKE CREATE ON DATABASE postgres FROM PUBLIC")
+        } finally {
+          admin.close()
+        }
+
+        val dsLimited = pg3.getDatabase("limited_user", "postgres")
+        val limitedMigrator = new Migrator(
+          dsLimited, SupportedDatabase.Postgres, migrations, schema = "limited_pre_existing"
+        )
+        limitedMigrator.migrate()
+
+        val verifyLimited = dsLimited.getConnection
+        try {
+          verifyLimited.setSchema("limited_pre_existing")
+          val rs10 = verifyLimited.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+          rs10.next()
+          assert(rs10.getLong(1) == 1, "Expected 1 migration recorded by limited role on pre-existing schema")
+          rs10.close()
+        } finally {
+          verifyLimited.close()
+        }
+      } finally {
+        pg3.close()
+      }
+
+      println("Test 10 passed: autoCreateSchema=true on pre-existing schema requires no CREATE on database")
+
       println("All Postgres cleanAndMigrate tests passed!")
     } finally {
       pg.close()

--- a/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
@@ -2,11 +2,11 @@ import nomad.{Migrator, SQLMigration, SupportedDatabase}
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 
 object Main {
-  def main(args: Array[String]): Unit = {
-    // On NixOS zonky's bundled generic-Linux binaries fail to load. NOMAD_PG_TARBALL
-    // (set by the flake devshell) overrides the binary source with a tarball of the
-    // system postgres.
-    val pg = sys.env.get("NOMAD_PG_TARBALL").filter(_.nonEmpty) match {
+  // On NixOS zonky's bundled generic-Linux binaries fail to load. NOMAD_PG_TARBALL
+  // (set by the flake devshell) overrides the binary source with a tarball of the
+  // system postgres.
+  private def startEmbeddedPostgres(): EmbeddedPostgres =
+    sys.env.get("NOMAD_PG_TARBALL").filter(_.nonEmpty) match {
       case Some(path) =>
         // nix-store postgres defaults unix_socket_directories to /run/postgresql,
         // which doesn't exist in this sandbox — point it at the JVM temp dir instead.
@@ -17,6 +17,9 @@ object Main {
           .start()
       case None => EmbeddedPostgres.start()
     }
+
+  def main(args: Array[String]): Unit = {
+    val pg = startEmbeddedPostgres()
 
     try {
       val ds = pg.getPostgresDatabase()
@@ -218,7 +221,7 @@ object Main {
       // additionally verifies that the fix is idempotent: a second cleanAndMigrate() call
       // after self-heal must also converge (the bug was described as self-perpetuating).
       // Use a fresh embedded PG so earlier tests do not interfere with the public schema.
-      val pg2 = EmbeddedPostgres.start()
+      val pg2 = startEmbeddedPostgres()
       try {
         val ds2 = pg2.getPostgresDatabase()
 

--- a/sbt-plugin/src/sbt-test/nomad/clean-and-migrate/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/clean-and-migrate/src/main/scala/Main.scala
@@ -110,6 +110,42 @@ object Main {
     rs5.close()
     conn4.close()
 
+    // Test: cleanAndMigrate self-heals when schema does not exist (autoCreateSchema=true default)
+    val missingSchemaMigrator = new Migrator(
+      ds, SupportedDatabase.H2, migrations, schema = "NEVER_CREATED"
+    )
+    missingSchemaMigrator.cleanAndMigrate()
+
+    val conn6 = ds.getConnection
+    conn6.setSchema("NEVER_CREATED")
+    val rs6 = conn6.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+    rs6.next()
+    assert(rs6.getLong(1) == 1, "Expected 1 migration recorded after self-heal on missing schema")
+    rs6.close()
+    conn6.close()
+
+    // Test: autoCreateSchema=false must not silently create a missing schema.
+    // H2 surfaces the missing schema either at setSchema or at the first DDL attempt;
+    // we assert that a SQL-level failure mentioning the schema name bubbles up.
+    val strictMigrator = new Migrator(
+      ds, SupportedDatabase.H2, migrations,
+      schema = "STRICT_MISSING", autoCreateSchema = false
+    )
+    try {
+      strictMigrator.cleanAndMigrate()
+      throw new AssertionError("Expected failure when autoCreateSchema=false and schema is missing")
+    } catch {
+      case e: java.sql.SQLException =>
+        assert(
+          e.getMessage != null && e.getMessage.toUpperCase.contains("STRICT_MISSING"),
+          s"Expected H2 error referencing missing schema, got: ${e.getMessage}"
+        )
+      case e: RuntimeException if e.getCause.isInstanceOf[java.sql.SQLException]
+          && e.getCause.getMessage != null
+          && e.getCause.getMessage.toUpperCase.contains("STRICT_MISSING") =>
+        // expected — wrapped in Migrator's RuntimeException
+    }
+
     println("cleanAndMigrate tests passed!")
   }
 }

--- a/sbt-plugin/src/sbt-test/nomad/migrate-custom-schema/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/migrate-custom-schema/src/main/scala/Main.scala
@@ -45,5 +45,42 @@ object Main {
     assert(!pub.contains("NOMAD_MIGRATIONS"), s"'nomad_migrations' should NOT be in PUBLIC schema")
 
     println("Custom schema migrate test passed!")
+
+    // Test: migrate self-heals when the configured schema does not exist
+    val selfHealMigrator = new Migrator(
+      ds, SupportedDatabase.H2, migrations, schema = "NOT_THERE_YET"
+    )
+    selfHealMigrator.migrate()
+
+    val conn3 = ds.getConnection
+    conn3.setSchema("NOT_THERE_YET")
+    val rs = conn3.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+    rs.next()
+    assert(rs.getLong(1) == 1, "Expected 1 migration recorded after migrate self-heal on missing schema")
+    rs.close()
+    conn3.close()
+
+    // Test: migrate with autoCreateSchema=false must fail when schema is missing.
+    // Assert a SQL-level failure that references the schema name — not just any error.
+    val strictMigrator = new Migrator(
+      ds, SupportedDatabase.H2, migrations,
+      schema = "STRICT_MISSING_MIGRATE", autoCreateSchema = false
+    )
+    try {
+      strictMigrator.migrate()
+      throw new AssertionError("Expected migrate() to fail when autoCreateSchema=false and schema is missing")
+    } catch {
+      case e: java.sql.SQLException =>
+        assert(
+          e.getMessage != null && e.getMessage.toUpperCase.contains("STRICT_MISSING_MIGRATE"),
+          s"Expected H2 error referencing missing schema, got: ${e.getMessage}"
+        )
+      case e: RuntimeException if e.getCause.isInstanceOf[java.sql.SQLException]
+          && e.getCause.getMessage != null
+          && e.getCause.getMessage.toUpperCase.contains("STRICT_MISSING_MIGRATE") =>
+        // expected — wrapped in Migrator's RuntimeException
+    }
+
+    println("migrate self-heal tests passed!")
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / version := "0.1.1-SNAPSHOT"


### PR DESCRIPTION
## Summary

- `Migrator.cleanAndMigrate()` and `Migrator.migrate()` no longer fail unrecoverably when the configured schema does not exist (`no schema has been selected to create in`). `isSchemaEmpty` conflated "empty" with "missing", so `cleanAndMigrate` skipped the recreate branch and `migrate()` then hit the unqualified `CREATE TYPE nomad_migration_type`. The failure was self-perpetuating.
- Fix: new `autoCreateSchema: Boolean = true` constructor parameter drives `CREATE SCHEMA IF NOT EXISTS` at the start of both entry points. Opt-out preserved for least-privilege roles.
- Binary compat with `0.1.0` preserved via a secondary 5-arg `Migrator` constructor; reflection in the plugin selects the primary constructor by maximum arity so it stays deterministic.
- sbt plugin gains `nomadSchema` (default `"public"`) and `nomadAutoCreateSchema` (default `true`) settings — the schema is no longer hard-coded inside the plugin.

## Test plan

- [x] `sbt scripted nomad/clean-and-migrate` (H2) — self-heal + opt-out assertions
- [x] `sbt scripted nomad/clean-and-migrate-postgres` — Tests 1-9 including canonical `DROP SCHEMA public CASCADE` repro + idempotent second call
- [x] `sbt scripted nomad/migrate-custom-schema` — `migrate()` entry point, self-heal + opt-out
- [x] `sbt scripted nomad/migrate` — plugin task still works with refactored settings
- [x] End-to-end validation in a downstream consumer: manually dropped the schema, ran `nomadMigrate`, confirmed the schema was recreated and migrations applied.

### Test coverage notes

- **Test 7 (PG)** asserts the exact original bug symptom surfaces when `autoCreateSchema=false` — pins the regression.
- **Test 9 (PG)** replays the verbatim repro from the bug report (`DROP SCHEMA public CASCADE` → `cleanAndMigrate`) plus a second invocation proving the fix is idempotent against the self-perpetuating nature of the original failure.
- H2 opt-out tests assert a `SQLException` that references the missing schema name — catches any future regression where the opt-out accidentally starts auto-creating.