### PR TITLE
Track .envrc + make postgres scripted test work on NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,4 @@ metals.sbt
 # Claude Code
 .claude/
 MEMORY.md
-.envrc
 .direnv/

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,22 @@
       }) supportedSystems);
     in {
       devShells = forEachSystem (system:
-        let pkgs = nixpkgs.legacyPackages.${system};
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          # Tarball of pkgs.postgresql in the layout zonky's embedded-postgres expects
+          # (bin/, lib/, share/ at root). Used by the postgres scripted test on NixOS,
+          # where the bundled generic-Linux binaries can't run.
+          pgTarball = pkgs.runCommand "nomad-zonky-postgres.txz" {
+            nativeBuildInputs = [ pkgs.gnutar pkgs.xz ];
+          } ''
+            tar -cJf $out -C ${pkgs.postgresql} bin lib share
+          '';
         in {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [ jdk21 sbt ];
             shellHook = ''
               export JAVA_HOME="${pkgs.jdk21}"
+              export NOMAD_PG_TARBALL="${pgTarball}"
             '';
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs }:
     let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forEachSystem = f: builtins.listToAttrs (map (system: {
         name = system;
         value = f system;

--- a/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
@@ -3,7 +3,20 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 
 object Main {
   def main(args: Array[String]): Unit = {
-    val pg = EmbeddedPostgres.start()
+    // On NixOS zonky's bundled generic-Linux binaries fail to load. NOMAD_PG_TARBALL
+    // (set by the flake devshell) overrides the binary source with a tarball of the
+    // system postgres.
+    val pg = sys.env.get("NOMAD_PG_TARBALL").filter(_.nonEmpty) match {
+      case Some(path) =>
+        // nix-store postgres defaults unix_socket_directories to /run/postgresql,
+        // which doesn't exist in this sandbox — point it at the data dir instead.
+        EmbeddedPostgres
+          .builder()
+          .setPgBinaryResolver((_, _) => new java.io.FileInputStream(path))
+          .setServerConfig("unix_socket_directories", System.getProperty("java.io.tmpdir"))
+          .start()
+      case None => EmbeddedPostgres.start()
+    }
 
     try {
       val ds = pg.getPostgresDatabase()

--- a/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/clean-and-migrate-postgres/src/main/scala/Main.scala
@@ -9,7 +9,7 @@ object Main {
     val pg = sys.env.get("NOMAD_PG_TARBALL").filter(_.nonEmpty) match {
       case Some(path) =>
         // nix-store postgres defaults unix_socket_directories to /run/postgresql,
-        // which doesn't exist in this sandbox — point it at the data dir instead.
+        // which doesn't exist in this sandbox — point it at the JVM temp dir instead.
         EmbeddedPostgres
           .builder()
           .setPgBinaryResolver((_, _) => new java.io.FileInputStream(path))


### PR DESCRIPTION
## Summary

- Track `.envrc` (with `use flake`) so contributors with direnv + nix-direnv get the devshell auto-loaded on `cd`, rather than authoring the file themselves or running `nix develop` manually.
- Fix `nomad/clean-and-migrate-postgres` scripted test on NixOS. zonky's bundled generic-Linux Postgres binaries fail to load there ("NixOS cannot run dynamically linked executables intended for generic linux environments"). The devshell now exports `NOMAD_PG_TARBALL` pointing at an XZ tar of `pkgs.postgresql` (`bin`, `lib`, `share`); the test feeds that through a custom `PgBinaryResolver` and overrides `unix_socket_directories` to `$TMPDIR` (nix postgres defaults to `/run/postgresql`, which doesn't exist in the sandbox).
- CI on Ubuntu is unaffected: env var unset → `EmbeddedPostgres.start()` runs as before.

Closes #4.

## Test plan

- [x] `sbt clean scripted doc` passes locally on NixOS (22/22 scripted tests + doc).
- [x] CI passes on Ubuntu (no env var set, default zonky path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)