### PR TITLE
feat: add nomadRebase task for fast dev database cloning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Nomad — Project Agent Context
+
+## Maintainer
+
+`novamage@magaran.com` (GPG `6DC61FDE08C36DE2`) = main pusher maintainer.
+Owner Shortcut from [org AGENTS.md](../../AGENTS.md) applies here →
+`gh pr merge --admin --merge` and direct `git push` work without joining
+`temporary-pr-overlord` or `temporary-hotfix-overlord`.
+
+Agent path: verify owner via signed-commit check (`git log -1 --pretty=format:'%G? %GS %ae %GK'` — see "Owner Verification" in org AGENTS.md),
+then merge/push directly. On 403: stop, report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/core/src/main/scala/nomad/NomadMigrations.scala
+++ b/core/src/main/scala/nomad/NomadMigrations.scala
@@ -34,4 +34,17 @@ trait NomadMigrations {
 
   /** The ordered list of migrations to apply. */
   def migrations: Vector[Migration]
+
+  /** An optional second datasource pointing at a long-lived "rebase" database on the same
+    * Postgres cluster as [[datasource]], used by the `nomadRebase` sbt task.
+    *
+    * When configured, `nomadRebase` drops the target database (the one [[datasource]]
+    * points at) and re-clones it from this rebase database via a fast Postgres
+    * `CREATE DATABASE ... WITH TEMPLATE` file-level copy, then runs any pending
+    * migrations on top. The rebase database is never modified.
+    *
+    * Defaults to `None`. Override to enable `nomadRebase`. Postgres only — the task
+    * fails if [[database]] is not [[SupportedDatabase.Postgres]].
+    */
+  def rebaseDatasource: Option[DataSource] = None
 }

--- a/core/src/main/scala/nomad/Rebaser.scala
+++ b/core/src/main/scala/nomad/Rebaser.scala
@@ -44,6 +44,16 @@ class Rebaser(
   db: SupportedDatabase
 ) {
 
+  /** Tags a datasource in error messages so users know which one failed. */
+  private enum Role derives CanEqual {
+    case Main, Rebase
+
+    def label: String = this match {
+      case Main   => "main"
+      case Rebase => "rebase"
+    }
+  }
+
   private val logger = LoggerFactory.getLogger(classOf[Rebaser])
 
   /** Drops the target database and recreates it as a fast file-level clone of the
@@ -81,10 +91,10 @@ class Rebaser(
         )
     }
 
-    val (mainUrl, targetDbName)     = readDatasourceMetadata(mainDatasource, role = "main")
-    val (rebaseUrl, rebaseDbName)   = readDatasourceMetadata(rebaseDatasource, role = "rebase")
-    val mainServer                  = parseSingleHost(mainUrl, role = "main")
-    val rebaseServer                = parseSingleHost(rebaseUrl, role = "rebase")
+    val (mainUrl, targetDbName)   = readDatasourceMetadata(mainDatasource, Role.Main)
+    val (rebaseUrl, rebaseDbName) = readDatasourceMetadata(rebaseDatasource, Role.Rebase)
+    val mainServer                = parseSingleHost(mainUrl, Role.Main)
+    val rebaseServer              = parseSingleHost(rebaseUrl, Role.Rebase)
 
     if (mainServer != rebaseServer) {
       throw new IllegalArgumentException(
@@ -105,10 +115,53 @@ class Rebaser(
     )
 
     Using.resource(rebaseDatasource.getConnection) { conn =>
-      terminateOtherSessions(conn, targetDbName)
-      dropDatabaseIfExists(conn, targetDbName)
-      terminateOtherSessions(conn, rebaseDbName)
-      createDatabaseFromTemplate(conn, targetDbName, rebaseDbName)
+      // DROP DATABASE and CREATE DATABASE ... WITH TEMPLATE cannot run inside a
+      // transaction block. DataSource#getConnection does not guarantee autoCommit
+      // is true (pools configured for ORM-style apps often default to false), so
+      // force it true for the duration of admin work and restore the borrowed
+      // state on the way out — pooled connections returned in a different state
+      // than they were borrowed in are a known source of cross-borrow surprises.
+      val originalAutoCommit = conn.getAutoCommit
+      conn.setAutoCommit(true)
+      try
+        // ALLOW_CONNECTIONS=false on target closes the gate against the user's
+        // app pool refilling connections to target between our terminate and our
+        // drop — that race is what would otherwise leave residual sessions and
+        // make DROP DATABASE fail with "database 'target' is being accessed by
+        // other users".
+        //
+        // We deliberately do not apply the same trick to the rebase database:
+        //   1. Postgres rejects ALTER DATABASE ... ALLOW_CONNECTIONS=false on
+        //      the session's own current database (which is rebase, because the
+        //      admin connection is borrowed from rebaseDatasource) with
+        //      "cannot disallow connections for current database".
+        //   2. Conceptually the rebase database is a passive long-lived template
+        //      that no developer workflow connects to between rebases, so the
+        //      pool-refill race the gate guards against doesn't realistically
+        //      arise on the rebase side. We still terminate other sessions on
+        //      rebase immediately before CREATE ... TEMPLATE so any opportunistic
+        //      stragglers are cleared, but the rebase side remains technically
+        //      racy — if your rebase database is being actively connected to
+        //      (unusual), close those sessions before invoking nomadRebase.
+        withAllowConnectionsDisabled(conn, targetDbName) {
+          terminateOtherSessions(conn, targetDbName)
+          dropDatabaseIfExists(conn, targetDbName)
+          terminateOtherSessions(conn, rebaseDbName)
+          createDatabaseFromTemplate(conn, targetDbName, rebaseDbName)
+          // The new target inherits ALLOW_CONNECTIONS from the rebase template,
+          // which we never touched (still true). The surrounding `finally`
+          // re-runs ALTER ... ALLOW_CONNECTIONS=true on target — a no-op in the
+          // happy path, load-bearing if CREATE failed and the freshly-dropped
+          // target was somehow recreated by something else in a non-true state.
+        }
+      finally
+        try conn.setAutoCommit(originalAutoCommit)
+        catch {
+          case e: java.sql.SQLException =>
+            logger.warn(
+              s"Could not restore autoCommit=$originalAutoCommit on rebase admin connection: ${e.getMessage}"
+            )
+        }
     }
     logger.info(
       s"Rebase complete: database '$targetDbName' is now a fresh clone of '$rebaseDbName'."
@@ -116,19 +169,19 @@ class Rebaser(
   }
 
   /** Returns `(jdbcUrl, currentDatabaseName)` read from a short-lived connection on `ds`. */
-  private def readDatasourceMetadata(ds: DataSource, role: String): (String, String) = {
+  private def readDatasourceMetadata(ds: DataSource, role: Role): (String, String) = {
     try
       Using.resource(ds.getConnection) { conn =>
         val url = conn.getMetaData.getURL
         if (url == null || url.isEmpty) {
           throw new IllegalStateException(
-            s"$role datasource did not expose a JDBC URL via getMetaData.getURL."
+            s"${role.label} datasource did not expose a JDBC URL via getMetaData.getURL."
           )
         }
         val catalog = conn.getCatalog
         if (catalog == null || catalog.isEmpty) {
           throw new IllegalStateException(
-            s"$role datasource did not expose its database name via Connection.getCatalog."
+            s"${role.label} datasource did not expose its database name via Connection.getCatalog."
           )
         }
         (url, catalog)
@@ -136,9 +189,14 @@ class Rebaser(
     catch {
       case e: IllegalStateException => throw e
       case e: java.sql.SQLException =>
+        val hint = role match {
+          case Role.Main =>
+            "For a rebase, the target database must already exist (Nomad does not create databases)."
+          case Role.Rebase =>
+            "Check that the rebase database exists and the rebaseDatasource configuration is correct."
+        }
         throw new IllegalStateException(
-          s"Could not connect to $role datasource. For a rebase, the target database must already exist " +
-            s"(Nomad does not create databases). Underlying error: ${e.getMessage}",
+          s"Could not connect to ${role.label} datasource. $hint Underlying error: ${e.getMessage}",
           e
         )
     }
@@ -147,26 +205,55 @@ class Rebaser(
   /** Parses a single `host:port` (or bare `host`) from a Postgres JDBC URL.
     * Rejects non-Postgres URLs and multi-host failover URLs.
     */
-  private def parseSingleHost(url: String, role: String): String = {
+  private def parseSingleHost(url: String, role: Role): String = {
     val prefix = "jdbc:postgresql://"
     if (!url.startsWith(prefix)) {
       throw new IllegalArgumentException(
-        s"$role datasource is not a Postgres JDBC URL (got: $url). nomadRebase requires Postgres."
+        s"${role.label} datasource is not a Postgres JDBC URL (got: $url). nomadRebase requires Postgres."
       )
     }
     val afterPrefix = url.substring(prefix.length)
     val authority   = afterPrefix.takeWhile(c => c != '/' && c != '?')
     if (authority.contains(',')) {
       throw new IllegalArgumentException(
-        s"$role datasource uses a multi-host JDBC URL ($url). nomadRebase requires a single-host URL."
+        s"${role.label} datasource uses a multi-host JDBC URL ($url). nomadRebase requires a single-host URL."
       )
     }
     if (authority.isEmpty) {
       throw new IllegalArgumentException(
-        s"$role datasource URL does not include a host ($url)."
+        s"${role.label} datasource URL does not include a host ($url)."
       )
     }
     authority
+  }
+
+  /** Runs `body` with `ALLOW_CONNECTIONS=false` set on `dbName`, restoring `true`
+    * in a `finally` block. The restore swallows SQL errors (logged at warn) so
+    * the body's exception is not masked — e.g., if `body` dropped the database
+    * outright and the restore can't find it. The new database created from a
+    * template inherits `ALLOW_CONNECTIONS=false` from the template, so a guard
+    * scoped to the target name covers the post-CREATE restore as well.
+    */
+  private def withAllowConnectionsDisabled[A](conn: Connection, dbName: String)(body: => A): A = {
+    setAllowConnections(conn, dbName, allow = false)
+    try body
+    finally
+      try setAllowConnections(conn, dbName, allow = true)
+      catch {
+        case e: java.sql.SQLException =>
+          logger.warn(
+            s"Could not restore ALLOW_CONNECTIONS=true on database '$dbName' " +
+              s"(likely dropped or unreachable): ${e.getMessage}"
+          )
+      }
+  }
+
+  private def setAllowConnections(conn: Connection, dbName: String, allow: Boolean): Unit = {
+    Using.resource(conn.createStatement()) { stmt =>
+      val _ = stmt.execute(
+        s"""ALTER DATABASE "${escapeIdentifier(dbName)}" WITH ALLOW_CONNECTIONS ${if (allow) "true" else "false"}"""
+      )
+    }
   }
 
   private def terminateOtherSessions(conn: Connection, dbName: String): Unit = {
@@ -177,20 +264,45 @@ class Rebaser(
     ) { ps =>
       ps.setString(1, dbName)
       Using.resource(ps.executeQuery()) { rs =>
-        var terminated = 0
-        while (rs.next()) terminated += 1
-        if (terminated > 0) {
-          logger.info(s"Terminated $terminated other session(s) on database '$dbName'.")
+        // pg_terminate_backend returns false when the PID exited between the
+        // SELECT and the signal — count only true returns so the log reflects
+        // what was actually killed, and warn separately on the race.
+        var succeeded = 0
+        var failed    = 0
+        while (rs.next()) {
+          if (rs.getBoolean(1)) succeeded += 1 else failed += 1
+        }
+        if (succeeded > 0) {
+          logger.info(s"Terminated $succeeded other session(s) on database '$dbName'.")
+        }
+        if (failed > 0) {
+          logger.warn(
+            s"Failed to terminate $failed session(s) on database '$dbName' " +
+              s"(likely already exited between selection and signal)."
+          )
         }
       }
     }
   }
 
   private def dropDatabaseIfExists(conn: Connection, dbName: String): Unit = {
-    Using.resource(conn.createStatement()) { stmt =>
-      val _ = stmt.execute(s"""DROP DATABASE IF EXISTS "${escapeIdentifier(dbName)}"""")
+    if (databaseExists(conn, dbName)) {
+      Using.resource(conn.createStatement()) { stmt =>
+        // IF EXISTS retained for the small race window between the pg_database
+        // check above and the DROP hitting the server.
+        val _ = stmt.execute(s"""DROP DATABASE IF EXISTS "${escapeIdentifier(dbName)}"""")
+      }
+      logger.info(s"Dropped database '$dbName'.")
+    } else {
+      logger.info(s"Database '$dbName' did not exist; skipping drop.")
     }
-    logger.info(s"Dropped database '$dbName'.")
+  }
+
+  private def databaseExists(conn: Connection, dbName: String): Boolean = {
+    Using.resource(conn.prepareStatement("SELECT 1 FROM pg_database WHERE datname = ?")) { ps =>
+      ps.setString(1, dbName)
+      Using.resource(ps.executeQuery())(_.next())
+    }
   }
 
   private def createDatabaseFromTemplate(conn: Connection, target: String, template: String): Unit = {

--- a/core/src/main/scala/nomad/Rebaser.scala
+++ b/core/src/main/scala/nomad/Rebaser.scala
@@ -1,0 +1,207 @@
+package nomad
+
+import java.sql.Connection
+import javax.sql.DataSource
+import org.slf4j.LoggerFactory
+import scala.util.Using
+
+/** Rebases a target Postgres database from a long-lived "rebase" template database
+  * on the same Postgres cluster, using a fast file-level template copy.
+  *
+  * The rebase workflow is designed for developers who maintain a long-lived rebase
+  * database at a known-good point in time (e.g., a restored production backup with
+  * most migrations already applied). When their working database becomes
+  * contaminated or needs to be reset, [[rebase]] drops it and re-clones it from
+  * the rebase database via `CREATE DATABASE target WITH TEMPLATE rebase`. Any
+  * pending migrations can then be applied on top via [[Migrator.migrate]].
+  *
+  * The copy is a Postgres file-level operation: it does not re-execute schema or
+  * data DDL, so it is dramatically faster than restoring from a logical dump.
+  *
+  * '''Destructive''': this drops the entire target database. The caller is
+  * responsible for any confirmation prompting.
+  *
+  * Constraints (all enforced by [[rebase]] and reported as exceptions):
+  *   - Database type must be [[SupportedDatabase.Postgres]] (H2 is rejected).
+  *   - Both datasources must connect to the same Postgres cluster — the host
+  *     and port parsed from each JDBC URL must match exactly.
+  *   - Multi-host failover JDBC URLs are rejected.
+  *   - The target database must already exist (Nomad does not create databases).
+  *   - Target and rebase database names must differ.
+  *
+  * @param mainDatasource the working datasource — its target database is dropped
+  *                       and recreated from the rebase template
+  * @param rebaseDatasource the rebase datasource — never dropped or modified;
+  *                         used both as the template source and as the connection
+  *                         from which `DROP DATABASE` and `CREATE DATABASE` are
+  *                         issued (these statements cannot be issued from a
+  *                         connection on the target database itself)
+  * @param db the database type (must be Postgres)
+  */
+class Rebaser(
+  mainDatasource: DataSource,
+  rebaseDatasource: DataSource,
+  db: SupportedDatabase
+) {
+
+  private val logger = LoggerFactory.getLogger(classOf[Rebaser])
+
+  /** Drops the target database and recreates it as a fast file-level clone of the
+    * rebase database.
+    *
+    * Sequence:
+    *   1. Verify Postgres, parse host:port from each JDBC URL, fail on mismatch.
+    *   2. Resolve target and rebase database names via `Connection.getCatalog`.
+    *   3. From a single connection on the rebase datasource:
+    *      - terminate other sessions on the target database,
+    *      - `DROP DATABASE IF EXISTS target`,
+    *      - terminate other sessions on the rebase database (required because
+    *        Postgres rejects `CREATE DATABASE ... TEMPLATE` if any other session
+    *        is connected to the template source),
+    *      - `CREATE DATABASE target WITH TEMPLATE rebase`.
+    *
+    * The issuing session is excluded from the terminate step via
+    * `pg_backend_pid()`; Postgres permits the template source to have the
+    * issuing session connected during the copy as long as no other sessions
+    * are present.
+    *
+    * @throws java.lang.IllegalArgumentException if `db` is not Postgres, the datasources
+    *                                            are on different servers, a URL is
+    *                                            multi-host or non-Postgres, or target ==
+    *                                            rebase
+    * @throws java.lang.IllegalStateException if the target database cannot be reached
+    *                                         (typically because it does not yet exist)
+    */
+  def rebase(): Unit = {
+    db match {
+      case SupportedDatabase.Postgres => ()
+      case other =>
+        throw new IllegalArgumentException(
+          s"nomadRebase requires Postgres, got: $other"
+        )
+    }
+
+    val (mainUrl, targetDbName)     = readDatasourceMetadata(mainDatasource, role = "main")
+    val (rebaseUrl, rebaseDbName)   = readDatasourceMetadata(rebaseDatasource, role = "rebase")
+    val mainServer                  = parseSingleHost(mainUrl, role = "main")
+    val rebaseServer                = parseSingleHost(rebaseUrl, role = "rebase")
+
+    if (mainServer != rebaseServer) {
+      throw new IllegalArgumentException(
+        s"Main and rebase datasources must be on the same Postgres server. " +
+          s"Main is on '$mainServer', rebase is on '$rebaseServer'."
+      )
+    }
+
+    if (targetDbName == rebaseDbName) {
+      throw new IllegalArgumentException(
+        s"Target and rebase databases must differ (both resolved to '$targetDbName'). " +
+          s"Refusing to template a database from itself."
+      )
+    }
+
+    logger.info(
+      s"Rebasing target database '$targetDbName' from rebase database '$rebaseDbName' on $mainServer."
+    )
+
+    Using.resource(rebaseDatasource.getConnection) { conn =>
+      terminateOtherSessions(conn, targetDbName)
+      dropDatabaseIfExists(conn, targetDbName)
+      terminateOtherSessions(conn, rebaseDbName)
+      createDatabaseFromTemplate(conn, targetDbName, rebaseDbName)
+    }
+    logger.info(
+      s"Rebase complete: database '$targetDbName' is now a fresh clone of '$rebaseDbName'."
+    )
+  }
+
+  /** Returns `(jdbcUrl, currentDatabaseName)` read from a short-lived connection on `ds`. */
+  private def readDatasourceMetadata(ds: DataSource, role: String): (String, String) = {
+    try
+      Using.resource(ds.getConnection) { conn =>
+        val url = conn.getMetaData.getURL
+        if (url == null || url.isEmpty) {
+          throw new IllegalStateException(
+            s"$role datasource did not expose a JDBC URL via getMetaData.getURL."
+          )
+        }
+        val catalog = conn.getCatalog
+        if (catalog == null || catalog.isEmpty) {
+          throw new IllegalStateException(
+            s"$role datasource did not expose its database name via Connection.getCatalog."
+          )
+        }
+        (url, catalog)
+      }
+    catch {
+      case e: IllegalStateException => throw e
+      case e: java.sql.SQLException =>
+        throw new IllegalStateException(
+          s"Could not connect to $role datasource. For a rebase, the target database must already exist " +
+            s"(Nomad does not create databases). Underlying error: ${e.getMessage}",
+          e
+        )
+    }
+  }
+
+  /** Parses a single `host:port` (or bare `host`) from a Postgres JDBC URL.
+    * Rejects non-Postgres URLs and multi-host failover URLs.
+    */
+  private def parseSingleHost(url: String, role: String): String = {
+    val prefix = "jdbc:postgresql://"
+    if (!url.startsWith(prefix)) {
+      throw new IllegalArgumentException(
+        s"$role datasource is not a Postgres JDBC URL (got: $url). nomadRebase requires Postgres."
+      )
+    }
+    val afterPrefix = url.substring(prefix.length)
+    val authority   = afterPrefix.takeWhile(c => c != '/' && c != '?')
+    if (authority.contains(',')) {
+      throw new IllegalArgumentException(
+        s"$role datasource uses a multi-host JDBC URL ($url). nomadRebase requires a single-host URL."
+      )
+    }
+    if (authority.isEmpty) {
+      throw new IllegalArgumentException(
+        s"$role datasource URL does not include a host ($url)."
+      )
+    }
+    authority
+  }
+
+  private def terminateOtherSessions(conn: Connection, dbName: String): Unit = {
+    Using.resource(
+      conn.prepareStatement(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ? AND pid <> pg_backend_pid()"
+      )
+    ) { ps =>
+      ps.setString(1, dbName)
+      Using.resource(ps.executeQuery()) { rs =>
+        var terminated = 0
+        while (rs.next()) terminated += 1
+        if (terminated > 0) {
+          logger.info(s"Terminated $terminated other session(s) on database '$dbName'.")
+        }
+      }
+    }
+  }
+
+  private def dropDatabaseIfExists(conn: Connection, dbName: String): Unit = {
+    Using.resource(conn.createStatement()) { stmt =>
+      val _ = stmt.execute(s"""DROP DATABASE IF EXISTS "${escapeIdentifier(dbName)}"""")
+    }
+    logger.info(s"Dropped database '$dbName'.")
+  }
+
+  private def createDatabaseFromTemplate(conn: Connection, target: String, template: String): Unit = {
+    Using.resource(conn.createStatement()) { stmt =>
+      val _ = stmt.execute(
+        s"""CREATE DATABASE "${escapeIdentifier(target)}" WITH TEMPLATE "${escapeIdentifier(template)}""""
+      )
+    }
+    logger.info(s"Created database '$target' from template '$template'.")
+  }
+
+  /** Doubles double-quote characters so an identifier can be safely embedded inside `"..."`. */
+  private def escapeIdentifier(id: String): String = id.replace("\"", "\"\"")
+}

--- a/sbt-plugin/src/main/scala/nomad/sbt/NomadPlugin.scala
+++ b/sbt-plugin/src/main/scala/nomad/sbt/NomadPlugin.scala
@@ -298,6 +298,7 @@ object NomadPlugin extends AutoPlugin {
     val nomadGraalSync = settingKey[Boolean]("Automatically sync migration resources to GraalVM native-image resource-config.json")
     val nomadGraalResourceConfigFile = settingKey[File]("Path to the GraalVM resource-config.json file")
     val nomadImportFlyway = taskKey[Unit]("Import Flyway versioned migrations into the Nomad manifest")
+    val nomadRebase = taskKey[Unit]("Drop and re-clone the target database from a rebase template database, then run pending migrations")
   }
 
   import autoImport._
@@ -317,6 +318,7 @@ object NomadPlugin extends AutoPlugin {
     nomadStatus / aggregate := false,
     nomadCreate / aggregate := false,
     nomadImportFlyway / aggregate := false,
+    nomadRebase / aggregate := false,
     nomadInit := {
       val log = streams.value.log
       val manifest = nomadManifestFile.value
@@ -599,6 +601,75 @@ object NomadPlugin extends AutoPlugin {
             loader.close()
           }
         }
+      }
+    },
+    nomadRebase := {
+      val log = streams.value.log
+      val interaction = interactionService.value
+      val cp = (Compile / fullClasspath).value.files
+      val className = nomadManifestClass.value
+      val table = nomadHistoryTable.value
+      val schema = nomadSchema.value
+      val autoCreateSchema = nomadAutoCreateSchema.value
+
+      val loader = new ChildFirstClassLoader(
+        cp.map(_.toURI.toURL).toArray,
+        getClass.getClassLoader
+      )
+
+      try {
+        val manifestClass = loader.loadClass(className + "$")
+        val instance = manifestClass.getField("MODULE$").get(null)
+        val datasourceMethod = manifestClass.getMethod("datasource")
+        val rebaseDatasourceMethod = manifestClass.getMethod("rebaseDatasource")
+        val databaseMethod = manifestClass.getMethod("database")
+        val migrationsMethod = manifestClass.getMethod("migrations")
+
+        val datasource = datasourceMethod.invoke(instance)
+        val rebaseDsOpt = rebaseDatasourceMethod.invoke(instance)
+        val database = databaseMethod.invoke(instance)
+        val migrations = migrationsMethod.invoke(instance)
+
+        // `rebaseDsOpt` is a scala.Option from the user's Scala 3 stdlib (loaded via the child-first
+        // classloader), distinct from this plugin's Scala 2.12 scala.Option. We invoke `isEmpty` /
+        // `get` reflectively on the instance's own class to stay classloader-agnostic.
+        val isEmpty = rebaseDsOpt.getClass.getMethod("isEmpty").invoke(rebaseDsOpt).asInstanceOf[Boolean]
+        if (isEmpty) {
+          throw new MessageOnlyException(
+            "rebaseDatasource is not configured. Override `def rebaseDatasource: Option[DataSource]` " +
+              "on your NomadMigrations manifest to enable nomadRebase."
+          )
+        }
+        val rebaseDs = rebaseDsOpt.getClass.getMethod("get").invoke(rebaseDsOpt)
+
+        log.warn(
+          "nomadRebase is destructive — it drops the target database and re-clones it from the rebase database."
+        )
+        val confirmed = Prompting.confirm(
+          interaction,
+          "Type 'y' to proceed, anything else to cancel: ",
+          default = false
+        )
+        if (!confirmed) {
+          log.info("Rebase canceled.")
+        } else {
+          val rebaserClass = loader.loadClass("nomad.Rebaser")
+          val rebaserCtor = rebaserClass.getConstructors.maxBy(_.getParameterCount)
+          val rebaser = rebaserCtor.newInstance(datasource, rebaseDs, database)
+          val rebaseMethod = rebaserClass.getMethod("rebase")
+          rebaseMethod.invoke(rebaser)
+
+          val migratorClass = loader.loadClass("nomad.Migrator")
+          val migratorCtor = migratorClass.getConstructors.maxBy(_.getParameterCount)
+          val migrator = migratorCtor.newInstance(
+            datasource, database, migrations, table, schema, java.lang.Boolean.valueOf(autoCreateSchema)
+          )
+          val migrateMethod = migratorClass.getMethod("migrate")
+          migrateMethod.invoke(migrator)
+          ()
+        }
+      } finally {
+        loader.close()
       }
     }
   )

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/build.sbt
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/build.sbt
@@ -1,0 +1,11 @@
+lazy val root = (project in file("."))
+  .settings(
+    name := "test-rebase-postgres",
+    version := "0.1.0",
+    scalaVersion := "3.8.2",
+    libraryDependencies ++= Seq(
+      "com.magaran" %% "nomad-core" % sys.props("plugin.version"),
+      "org.slf4j" % "slf4j-simple" % "2.0.17",
+      "io.zonky.test" % "embedded-postgres" % "2.1.0"
+    )
+  )

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("com.magaran" % "sbt-nomad" % v)
+  case _       => sys.error(
+    """|The system property 'plugin.version' is not defined.
+       |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+  )
+}

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/resources/migrations/M001_CreateUsers.sql
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/resources/migrations/M001_CreateUsers.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL
+);

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/resources/migrations/M002_CreateProducts.sql
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/resources/migrations/M002_CreateProducts.sql
@@ -1,0 +1,4 @@
+CREATE TABLE products (
+  id BIGINT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL
+);

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/scala/Main.scala
@@ -1,5 +1,8 @@
 import nomad.{Migrator, Rebaser, SQLMigration, SupportedDatabase}
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import javax.sql.DataSource
+import java.sql.Connection
+import java.util.concurrent.atomic.AtomicReference
 
 object Main {
   // On NixOS zonky's bundled generic-Linux binaries fail to load. NOMAD_PG_TARBALL
@@ -128,6 +131,86 @@ object Main {
       } finally {
         pg2.close()
       }
+
+      // --- Test 5: broken rebase datasource surfaces a rebase-specific error ---
+      // Regression for the bug where readDatasourceMetadata's SQLException wrapper
+      // always blamed the target database, even when the rebase datasource was the
+      // one that failed to connect.
+      val brokenRebaseDs = pg.getDatabase("postgres", "nonexistent_rebase_db")
+      try {
+        new Rebaser(targetDs, brokenRebaseDs, SupportedDatabase.Postgres).rebase()
+        throw new AssertionError("Expected IllegalStateException for broken rebase datasource")
+      } catch {
+        case e: IllegalStateException
+            if e.getMessage.contains("rebase datasource") &&
+              !e.getMessage.contains("target database must already exist") =>
+        // expected — message points at rebase, not at target
+      }
+      println("Test 5 passed: broken rebase datasource surfaces a rebase-specific error")
+
+      // --- Test 6: autoCommit=false rebase datasource succeeds AND state is restored ---
+      // Regression for the bug where DROP DATABASE / CREATE DATABASE ... WITH TEMPLATE
+      // failed because DataSource#getConnection does not guarantee autoCommit=true
+      // (pools configured for ORM-style apps often default to false). Also verifies
+      // Rebaser restores the original autoCommit state when done, so pooled
+      // connections are returned to the pool in the state they were borrowed in.
+      val admin2 = pg.getPostgresDatabase().getConnection
+      try {
+        admin2.createStatement().execute("CREATE DATABASE rebase2_db")
+        admin2.createStatement().execute("CREATE DATABASE target2_db")
+      } finally admin2.close()
+
+      val rebase2Ds = pg.getDatabase("postgres", "rebase2_db")
+      val target2Ds = pg.getDatabase("postgres", "target2_db")
+      new Migrator(rebase2Ds, SupportedDatabase.Postgres, baselineMigrations).migrate()
+
+      val seenAutoCommitAtClose = new AtomicReference[java.lang.Boolean]()
+
+      // Connection wrapper that captures the autoCommit state at close, so we can
+      // assert Rebaser restored the borrowed value (false here).
+      class TrackingConnection(underlying: Connection) extends Connection {
+        export underlying.{close as _, *}
+        def close(): Unit = {
+          seenAutoCommitAtClose.set(java.lang.Boolean.valueOf(underlying.getAutoCommit))
+          underlying.close()
+        }
+      }
+
+      // DataSource proxy that forces autoCommit=false on every borrow, simulating
+      // an ORM-style pool. Connections are returned through TrackingConnection so
+      // we can observe the autoCommit state at the moment Rebaser releases them.
+      val autoCommitFalseRebaseDs = new DataSource {
+        private def wrap(c: Connection): Connection = {
+          c.setAutoCommit(false)
+          new TrackingConnection(c)
+        }
+        def getConnection(): Connection                       = wrap(rebase2Ds.getConnection)
+        def getConnection(u: String, p: String): Connection   = wrap(rebase2Ds.getConnection(u, p))
+        def getLogWriter(): java.io.PrintWriter               = rebase2Ds.getLogWriter
+        def setLogWriter(out: java.io.PrintWriter): Unit      = rebase2Ds.setLogWriter(out)
+        def setLoginTimeout(s: Int): Unit                     = rebase2Ds.setLoginTimeout(s)
+        def getLoginTimeout(): Int                            = rebase2Ds.getLoginTimeout
+        def getParentLogger(): java.util.logging.Logger       = rebase2Ds.getParentLogger
+        def unwrap[T](iface: Class[T]): T                     = rebase2Ds.unwrap(iface)
+        def isWrapperFor(iface: Class[?]): Boolean            = rebase2Ds.isWrapperFor(iface)
+      }
+
+      new Rebaser(target2Ds, autoCommitFalseRebaseDs, SupportedDatabase.Postgres).rebase()
+
+      val v6 = target2Ds.getConnection
+      try {
+        val rs6 = v6.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+        rs6.next()
+        assert(rs6.getLong(1) == 1, "Expected M001 in cloned target2_db after autoCommit=false rebase")
+        rs6.close()
+      } finally v6.close()
+
+      val seenAtClose = Option(seenAutoCommitAtClose.get()).map(_.booleanValue)
+      assert(
+        seenAtClose.contains(false),
+        s"Expected autoCommit=false at close (Rebaser must restore borrowed state); got: $seenAtClose"
+      )
+      println("Test 6 passed: autoCommit=false datasource works and state is restored")
 
       println("All Rebaser tests passed!")
     } finally {

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/scala/Main.scala
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/src/main/scala/Main.scala
@@ -1,0 +1,137 @@
+import nomad.{Migrator, Rebaser, SQLMigration, SupportedDatabase}
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+
+object Main {
+  // On NixOS zonky's bundled generic-Linux binaries fail to load. NOMAD_PG_TARBALL
+  // (set by the flake devshell) overrides the binary source with a tarball of the
+  // system postgres.
+  private def startEmbeddedPostgres(): EmbeddedPostgres =
+    sys.env.get("NOMAD_PG_TARBALL").filter(_.nonEmpty) match {
+      case Some(path) =>
+        // nix-store postgres defaults unix_socket_directories to /run/postgresql,
+        // which doesn't exist in this sandbox — point it at the JVM temp dir instead.
+        EmbeddedPostgres
+          .builder()
+          .setPgBinaryResolver((_, _) => new java.io.FileInputStream(path))
+          .setServerConfig("unix_socket_directories", System.getProperty("java.io.tmpdir"))
+          .start()
+      case None => EmbeddedPostgres.start()
+    }
+
+  def main(args: Array[String]): Unit = {
+    val pg = startEmbeddedPostgres()
+    try {
+      // Bootstrap two databases on the same cluster: rebase_db acts as the long-lived
+      // template; target_db is the working database that will be repeatedly cloned.
+      val admin = pg.getPostgresDatabase().getConnection
+      try {
+        admin.createStatement().execute("CREATE DATABASE rebase_db")
+        admin.createStatement().execute("CREATE DATABASE target_db")
+      } finally {
+        admin.close()
+      }
+
+      val rebaseDs = pg.getDatabase("postgres", "rebase_db")
+      val targetDs = pg.getDatabase("postgres", "target_db")
+
+      val baselineMigrations = Vector(SQLMigration("migrations/M001_CreateUsers.sql"))
+
+      // Seed the rebase database: run M001, then insert a row so we can later assert
+      // the seeded data survives a file-level clone into target_db.
+      new Migrator(rebaseDs, SupportedDatabase.Postgres, baselineMigrations).migrate()
+      val seed = rebaseDs.getConnection
+      try {
+        seed.createStatement().execute("INSERT INTO users (id, name) VALUES (1, 'Charlie')")
+      } finally {
+        seed.close()
+      }
+
+      // --- Test 1: happy path — rebase target from rebase_db, then migrate forward ---
+      new Rebaser(targetDs, rebaseDs, SupportedDatabase.Postgres).rebase()
+
+      // After rebase the target should hold the seeded user and the M001 history row.
+      val v1 = targetDs.getConnection
+      try {
+        val rs1 = v1.createStatement().executeQuery("SELECT COUNT(*) FROM users WHERE name = 'Charlie'")
+        rs1.next()
+        assert(rs1.getLong(1) == 1, "Expected seeded 'Charlie' in cloned target")
+        rs1.close()
+        val rs2 = v1.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+        rs2.next()
+        assert(rs2.getLong(1) == 1, "Expected M001 history row in cloned target")
+        rs2.close()
+      } finally {
+        v1.close()
+      }
+
+      // Applying a new migration on top of the clone should only run M002.
+      val extendedManifest = baselineMigrations :+ SQLMigration("migrations/M002_CreateProducts.sql")
+      new Migrator(targetDs, SupportedDatabase.Postgres, extendedManifest).migrate()
+
+      val v2 = targetDs.getConnection
+      try {
+        val rsP = v2.createStatement().executeQuery("SELECT COUNT(*) FROM products")
+        rsP.next()
+        assert(rsP.getLong(1) == 0, "Expected products table created by M002")
+        rsP.close()
+        val rsU = v2.createStatement().executeQuery("SELECT COUNT(*) FROM users WHERE name = 'Charlie'")
+        rsU.next()
+        assert(rsU.getLong(1) == 1, "Expected 'Charlie' to remain after migrating on top of clone")
+        rsU.close()
+        val rsH = v2.createStatement().executeQuery("SELECT COUNT(*) FROM nomad_migrations")
+        rsH.next()
+        assert(rsH.getLong(1) == 2, "Expected M001 + M002 both recorded after rebase + migrate")
+        rsH.close()
+      } finally {
+        v2.close()
+      }
+      println("Test 1 passed: rebase + migrate cycle")
+
+      // --- Test 2: H2 is rejected ---
+      try {
+        new Rebaser(targetDs, rebaseDs, SupportedDatabase.H2).rebase()
+        throw new AssertionError("Expected IllegalArgumentException for H2")
+      } catch {
+        case e: IllegalArgumentException if e.getMessage.contains("Postgres") =>
+        // expected
+      }
+      println("Test 2 passed: H2 rejected")
+
+      // --- Test 3: target == rebase is rejected ---
+      try {
+        new Rebaser(rebaseDs, rebaseDs, SupportedDatabase.Postgres).rebase()
+        throw new AssertionError("Expected IllegalArgumentException for target == rebase")
+      } catch {
+        case e: IllegalArgumentException if e.getMessage.contains("must differ") =>
+        // expected
+      }
+      println("Test 3 passed: target == rebase rejected")
+
+      // --- Test 4: datasources on different servers are rejected ---
+      val pg2 = startEmbeddedPostgres()
+      try {
+        val otherAdmin = pg2.getPostgresDatabase().getConnection
+        try {
+          otherAdmin.createStatement().execute("CREATE DATABASE other_target")
+        } finally {
+          otherAdmin.close()
+        }
+        val otherTargetDs = pg2.getDatabase("postgres", "other_target")
+        try {
+          new Rebaser(otherTargetDs, rebaseDs, SupportedDatabase.Postgres).rebase()
+          throw new AssertionError("Expected IllegalArgumentException for different servers")
+        } catch {
+          case e: IllegalArgumentException if e.getMessage.contains("same Postgres server") =>
+          // expected
+        }
+        println("Test 4 passed: different servers rejected")
+      } finally {
+        pg2.close()
+      }
+
+      println("All Rebaser tests passed!")
+    } finally {
+      pg.close()
+    }
+  }
+}

--- a/sbt-plugin/src/sbt-test/nomad/rebase-postgres/test
+++ b/sbt-plugin/src/sbt-test/nomad/rebase-postgres/test
@@ -1,0 +1,4 @@
+# Tests Rebaser against a real PostgreSQL via embedded-postgres.
+# Covers: rebase + migrate happy path, H2 rejection, target == rebase rejection,
+# datasources on different servers rejection.
+> run

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.0"
+ThisBuild / version := "0.2.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.2-SNAPSHOT"
+ThisBuild / version := "0.2.0"

--- a/wiki/Clean-and-migrate.md
+++ b/wiki/Clean-and-migrate.md
@@ -1,5 +1,5 @@
 <p align="center"><a href="Table-of-Contents.md">Table of Contents</a></p>
-<p align="center"><a href="Migration-status.md">Migration Status</a> &lt; Clean and Migrate &gt; <a href="Database-and-schema-support.md">Database and Schema Support</a></p>
+<p align="center"><a href="Migration-status.md">Migration Status</a> &lt; Clean and Migrate &gt; <a href="Rebase.md">Rebase</a></p>
 
 For development and testing, `cleanAndMigrate` drops the entire schema and re-runs all migrations from scratch:
 
@@ -12,4 +12,4 @@ Before dropping, it checks that a Nomad history table exists in the schema to pr
 
 > **Note:** `cleanAndMigrate` is a method on `Migrator`, not an sbt task. It is intended to be called from your own code (e.g., test setup) where you can add any additional guardrails appropriate for your environment.
 
-Up next: [Database and schema support](Database-and-schema-support.md)
+Up next: [Rebase](Rebase.md)

--- a/wiki/Rebase.md
+++ b/wiki/Rebase.md
@@ -1,0 +1,51 @@
+<p align="center"><a href="Table-of-Contents.md">Table of Contents</a></p>
+<p align="center"><a href="Clean-and-migrate.md">Clean and Migrate</a> &lt; Rebase &gt; <a href="Database-and-schema-support.md">Database and Schema Support</a></p>
+
+For development against large or expensive-to-restore databases (e.g., a production backup that takes ten minutes to load), Nomad supports a "rebase" workflow: keep a long-lived rebase database at a known-good point in time, and reset your working database from it on demand.
+
+`nomadRebase` drops the target database and re-clones it from the rebase database via Postgres's `CREATE DATABASE target WITH TEMPLATE rebase`. The copy is a file-level operation, so it is dramatically faster than restoring from a logical dump. After cloning, any pending migrations are applied on top via the same logic as `nomadMigrate`.
+
+## Configuration
+
+Override `rebaseDatasource` on your manifest to point at the rebase database:
+
+```scala
+object Nomad extends NomadMigrations {
+  def database: SupportedDatabase = SupportedDatabase.Postgres
+  def datasource: DataSource = workingDatasource
+  override def rebaseDatasource: Option[DataSource] = Some(rebaseDb)
+  def migrations: Vector[Migration] = Vector(/* ... */)
+}
+```
+
+Then run:
+
+```
+sbt nomadRebase
+```
+
+The task is destructive (it drops the entire target database), so it prompts for confirmation before proceeding. There is no flag to bypass the prompt — `nomadRebase` is a developer convenience and is not intended for CI or production.
+
+## Constraints
+
+`nomadRebase` enforces several invariants and fails with a clear error if any are violated:
+
+- **Postgres only.** H2 is rejected. The fast-copy mechanism has no portable analog outside of Postgres.
+- **Same server.** Both datasources must connect to the same Postgres cluster — host and port are parsed from each JDBC URL and must match exactly.
+- **Single-host URLs.** Multi-host failover JDBC URLs (`jdbc:postgresql://h1:p1,h2:p2/db`) are rejected because the server identity cannot be determined unambiguously.
+- **Target must exist.** Nomad does not create databases. If the target database does not exist yet, create it manually (or via your usual provisioning) before running `nomadRebase`.
+- **Target ≠ rebase.** The two database names must differ; templating a database from itself is rejected.
+
+## How the clone works
+
+`nomadRebase` opens a single connection to the rebase datasource and, from there:
+
+1. Terminates any other sessions on the target database via `pg_terminate_backend`.
+2. Runs `DROP DATABASE IF EXISTS target`.
+3. Terminates any other sessions on the rebase database (excluding its own session — Postgres permits the issuing session to remain connected to the template source).
+4. Runs `CREATE DATABASE target WITH TEMPLATE rebase`.
+5. Hands off to `Migrator.migrate()` against the original target datasource to apply any pending manifest entries.
+
+The rebase database is never modified.
+
+Up next: [Database and schema support](Database-and-schema-support.md)

--- a/wiki/Table-of-Contents.md
+++ b/wiki/Table-of-Contents.md
@@ -15,6 +15,7 @@ Migrations
 * [Scala migrations](Scala-migrations.md)
 * [Migration status](Migration-status.md)
 * [Clean and migrate](Clean-and-migrate.md)
+* [Rebase](Rebase.md)
 
 Configuration
 -------------

--- a/wiki/sbt-reference.md
+++ b/wiki/sbt-reference.md
@@ -11,6 +11,7 @@ Tasks
 | `nomadMigrate` | Run all pending migrations |
 | `nomadStatus` | Show migration status (fails if problems detected) |
 | `nomadImportFlyway` | Import Flyway versioned migrations into the manifest and optionally import schema history |
+| `nomadRebase` | Drop the target database and re-clone it from a long-lived rebase database via a fast Postgres `CREATE DATABASE ... WITH TEMPLATE` copy, then run any pending migrations. Postgres only; requires `rebaseDatasource` to be set on the manifest. See [Rebase](Rebase.md). |
 
 Settings
 ========


### PR DESCRIPTION
## Summary

- New `nomadRebase` sbt task that drops the working database and re-clones it from a long-lived rebase template database via Postgres `CREATE DATABASE ... WITH TEMPLATE`, then runs any pending migrations on top.
- New overridable `def rebaseDatasource: Option[DataSource] = None` on `NomadMigrations` to opt in.
- New core `Rebaser` class encapsulates the destructive Postgres-only orchestration (same-server / single-host / target-exists / target≠rebase guards, session termination on both DBs, DROP + CREATE FROM TEMPLATE). `Migrator` is untouched (stays schema-scoped).
- Confirmation prompt is mandatory — no bypass flag. The task is a developer convenience, not for CI.

Closes #6.

## Test plan

- [x] `core/compile` + `sbtPlugin/compile` clean
- [x] `clean; test; doc` clean (no scaladoc warnings from new code)
- [x] All 23 scripted tests pass, including the new `nomad/rebase-postgres`
- [x] New scripted test exercises: happy-path rebase + migrate (seeded row + M001 history clone into target, then M002 applied on top), H2 rejection, target==rebase rejection, different-servers rejection (two embedded-pg instances)
- [ ] Manual end-to-end of `sbt nomadRebase` against a real developer Postgres cluster (the existing scripted test exercises `Rebaser` directly via `run`, matching the `clean-and-migrate-postgres` pattern — the sbt task wiring itself was not driven by the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)